### PR TITLE
Ensure database defaults support local usage

### DIFF
--- a/database.py
+++ b/database.py
@@ -1,20 +1,21 @@
 from sqlalchemy import create_engine
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import declarative_base, sessionmaker
 import os
 from dotenv import load_dotenv
 
 load_dotenv()
 
-DATABASE_URL = os.getenv("DATABASE_URL")
+DEFAULT_SQLITE_URL = "sqlite:///./devdash.db"
 
-if not DATABASE_URL:
-    raise ValueError("DATABASE_URL environment variable is required")
+DATABASE_URL = os.getenv("DATABASE_URL", DEFAULT_SQLITE_URL)
 
-engine = create_engine(DATABASE_URL)
+connect_args = {"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
+
+engine = create_engine(DATABASE_URL, connect_args=connect_args)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 Base = declarative_base()
+
 
 def get_db():
     db = SessionLocal()

--- a/models.py
+++ b/models.py
@@ -1,10 +1,9 @@
 from sqlalchemy import Column, Integer, String, Boolean, DateTime, Text, ForeignKey, Float
-from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 from datetime import datetime
 
-Base = declarative_base()
+from database import Base
 
 class User(Base):
     __tablename__ = "users"


### PR DESCRIPTION
## Summary
- default the database configuration to a local SQLite file when no environment variable is provided
- configure SQLite connections for thread safety and expose the shared declarative base to the models module
- update models to reuse the shared Base so metadata creation succeeds

## Testing
- python -c "import main"
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68db49f568fc8333b1db6208cc5aa166